### PR TITLE
Run tests with Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python${{ matrix.python-version }}


### PR DESCRIPTION
This PR aims to support Python 3.10. Note that `3.10` must be quoted, otherwise tests are executed with Python 3.1.