### PR TITLE
Fix correction of out-of-range continuous params of `CMAwM`

### DIFF
--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -206,10 +206,10 @@ class CMAwM:
                 )
                 return x_encoded, x
         x = self._cma._sample_solution()
-        x_encoded = x.copy()
-        x_encoded[self._continuous_idx] = self._repair_continuous_params(
+        x[self._continuous_idx] = self._repair_continuous_params(
             x[self._continuous_idx]
         )
+        x_encoded = x.copy()
         x_encoded[self._discrete_idx] = self._encoding_discrete_params(
             x[self._discrete_idx]
         )


### PR DESCRIPTION
Currently, the correlation logic of out-of-range parameters of `CMAwM` is inconsistent with `CMA`: `CMAwM` repairs only parameters used for evaluation, while `CMA` also repairs parameters used for its internal logic. This might cause a problem in `CMAwM` when out-of-range parameters are sampled frequently.
This PR aligns the logic of `CMAwM` with `CMA`.

Verification script:
```python
import numpy as np

from cmaes import CMAwM


def objective(x):
    return (x ** 2).sum()


def run_optimize():
    n_cont = 5
    bounds = np.tile([-1.0, 1.0], (n_cont + 1, 1))
    steps = np.concatenate([np.zeros(n_cont), np.ones(1)])
    # Note: large `sigma`
    optimizer = CMAwM(mean=np.zeros(n_cont + 1), sigma=20.0, bounds=bounds, steps=steps)

    while True:
        solutions = []
        for _ in range(optimizer.population_size):
            x_for_eval, x_for_tell = optimizer.ask()
            value = objective(x_for_eval)
            solutions.append((x_for_tell, value))
        optimizer.tell(solutions)

        if optimizer.should_stop():
            return value


if __name__ == "__main__":
    for _ in range(10):
        print(run_optimize())
```

Output before this fix:
```
4.0
3.0
6.0
4.0
4.0
4.0
4.0
2.0
5.0
3.0
```

Ouptut after this fix:
```
5.710282678329783e-22
4.1308922840579464e-22
3.484557168358208e-21
1.8641487416442012e-21
1.0642820137768132e-20
4.0519488712151966e-21
1.3830664413071854e-21
5.556940601920899e-24
1.5705063115532894e-21
6.1350675341124185e-21
```