### PR TITLE
Avoid to use `typing.List`, `typing.Dict`, and `typing.Tuple`.

### DIFF
--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -1,12 +1,11 @@
+from __future__ import annotations
+
 import math
 import numpy as np
 
 from typing import Any
 from typing import cast
-from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 
 _EPS = 1e-8
@@ -196,7 +195,7 @@ class CMA:
         self._funhist_term = 10 + math.ceil(30 * n_dim / population_size)
         self._funhist_values = np.empty(self._funhist_term * 2)
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         attrs = {}
         for name in self.__dict__:
             # Remove _rng in pickle serialized object.
@@ -209,7 +208,7 @@ class CMA:
             attrs[name] = getattr(self, name)
         return attrs
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         state["_C"] = _decompress_symmetric(state["_c_1d"])
         del state["_c_1d"]
         self.__dict__.update(state)
@@ -250,7 +249,7 @@ class CMA:
         x = self._repair_infeasible_params(x)
         return x
 
-    def _eigen_decomposition(self) -> Tuple[np.ndarray, np.ndarray]:
+    def _eigen_decomposition(self) -> tuple[np.ndarray, np.ndarray]:
         if self._B is not None and self._D is not None:
             return self._B, self._D
 
@@ -286,7 +285,7 @@ class CMA:
         param = np.where(param > self._bounds[:, 1], self._bounds[:, 1], param)
         return param
 
-    def tell(self, solutions: List[Tuple[np.ndarray, float]]) -> None:
+    def tell(self, solutions: list[tuple[np.ndarray, float]]) -> None:
         """Tell evaluation values"""
 
         assert len(solutions) == self._popsize, "Must tell popsize-length solutions."

--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import functools
 import numpy as np
 
 from typing import cast
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 
 from cmaes import CMA
@@ -200,7 +200,7 @@ class CMAwM:
     def reseed_rng(self, seed: int) -> None:
         self._cma.reseed_rng(seed)
 
-    def ask(self) -> Tuple[np.ndarray, np.ndarray]:
+    def ask(self) -> tuple[np.ndarray, np.ndarray]:
         """Sample a parameter and return (i) encoded x and (ii) raw x.
         The encoded x is used for the evaluation.
         The raw x is used for updating the distribution."""
@@ -243,7 +243,7 @@ class CMAwM:
         ).sum(axis=1)
         return x_enc.reshape(self._n_zdim)
 
-    def tell(self, solutions: List[Tuple[np.ndarray, float]]) -> None:
+    def tell(self, solutions: list[tuple[np.ndarray, float]]) -> None:
         """Tell evaluation values"""
         self._cma.tell(solutions)
         mean = self._cma._mean

--- a/cmaes/_sepcma.py
+++ b/cmaes/_sepcma.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import math
 import numpy as np
 
-from typing import Any, cast
-from typing import Dict
-from typing import List
+from typing import Any
+from typing import cast
 from typing import Optional
-from typing import Tuple
 
 
 _EPS = 1e-8
@@ -180,7 +180,7 @@ class SepCMA:
     def reseed_rng(self, seed: int) -> None:
         self._rng.seed(seed)
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         attrs = {}
         for name in self.__dict__:
             # Remove _rng in pickle serialized object.
@@ -189,7 +189,7 @@ class SepCMA:
             attrs[name] = getattr(self, name)
         return attrs
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         # Set _rng for unpickled object.
         setattr(self, "_rng", np.random.RandomState())
@@ -239,7 +239,7 @@ class SepCMA:
         param = np.where(param > self._bounds[:, 1], self._bounds[:, 1], param)
         return param
 
-    def tell(self, solutions: List[Tuple[np.ndarray, float]]) -> None:
+    def tell(self, solutions: list[tuple[np.ndarray, float]]) -> None:
         """Tell evaluation values"""
 
         assert len(solutions) == self._popsize, "Must tell popsize-length solutions."

--- a/cmaes/_warm_start.py
+++ b/cmaes/_warm_start.py
@@ -1,14 +1,14 @@
+from __future__ import annotations
+
 import math
 import numpy as np
 
-from typing import Tuple, List
-
 
 def get_warm_start_mgd(
-    source_solutions: List[Tuple[np.ndarray, float]],
+    source_solutions: list[tuple[np.ndarray, float]],
     gamma: float = 0.1,
     alpha: float = 0.1,
-) -> Tuple[np.ndarray, float, np.ndarray]:
+) -> tuple[np.ndarray, float, np.ndarray]:
     """Estimates a promising distribution of the source task, then
     returns a multivariate gaussian distribution (the mean vector
     and the covariance matrix) used for initialization of the CMA-ES.


### PR DESCRIPTION
`typing.List`, `typing.Tuple`, `typing.Dict` and `typing.Set` are deprecated at Python 3.9.
https://docs.python.org/3/library/typing.html#typing.Tuple

As written in [PEP 585](https://peps.python.org/pep-0585/#implementation), we can use `list`, `tuple`, `dict`, and `set` instead, even in Python 3.7 and Python 3.8.