### PR TITLE
Allow no discrete spaces in `CMAwM`

### DIFF
--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -132,21 +132,13 @@ class CMAwM:
         for i, discrete in enumerate(discrete_list):
             discrete_space[i, : len(discrete)] = discrete
 
-        n_zdim = len(discrete_space)
-        n_rdim = n_dim - n_zdim
-
-        margin = margin if margin is not None else 1 / (n_dim * population_size)
-        assert margin > 0, "margin must be non-zero positive value."
-
-        self._n_zdim = n_zdim
-        self._n_rdim = n_rdim
-
         # continuous_space contains low and high of each parameter.
         assert _is_valid_bounds(bounds[steps <= 0], mean[steps <= 0]), "invalid bounds"
-        self._n_max_resampling = n_max_resampling
 
         # discrete_space
+        self._n_zdim = len(discrete_space)
         self.margin = margin if margin is not None else 1 / (n_dim * population_size)
+        assert self.margin > 0, "margin must be non-zero positive value."
         self.z_space = discrete_space
         self.z_lim = (self.z_space[:, 1:] + self.z_space[:, :-1]) / 2
         for i in range(self._n_zdim):

--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -192,12 +192,12 @@ class CMAwM:
         The raw x is used for updating the distribution."""
         x = self._cma.ask()
         x_encoded = x.copy()
-        x_encoded[self._discrete_idx] = self._encoding_discrete_params(
+        x_encoded[self._discrete_idx] = self._encode_discrete_params(
             x[self._discrete_idx]
         )
         return x_encoded, x
 
-    def _encoding_discrete_params(self, discrete_param: np.ndarray) -> np.ndarray:
+    def _encode_discrete_params(self, discrete_param: np.ndarray) -> np.ndarray:
         """Encode the values into discrete domain."""
         mean = self._cma._mean
 

--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -198,16 +198,7 @@ class CMAwM:
         """Sample a parameter and return (i) encoded x and (ii) raw x.
         The encoded x is used for the evaluation.
         The raw x is used for updating the distribution."""
-        for i in range(self._n_max_resampling):
-            x = self._cma._sample_solution()
-            if self._cma._is_feasible(x):
-                x_encoded = x.copy()
-                x_encoded[self._discrete_idx] = self._encoding_discrete_params(
-                    x[self._discrete_idx]
-                )
-                return x_encoded, x
-        x = self._cma._sample_solution()
-        x = self._cma._repair_infeasible_params(x)
+        x = self._cma.ask()
         x_encoded = x.copy()
         x_encoded[self._discrete_idx] = self._encoding_discrete_params(
             x[self._discrete_idx]


### PR DESCRIPTION
For flexible use in other libraries such as Optuna, this PR allows input of no discrete spaces for `CMAwM` (should behave the same as `CMA` in that case).
Dependent on https://github.com/CyberAgentAILab/cmaes/pull/141.