### PR TITLE
Revert handling of infeasible discrete parameters

### DIFF
--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -198,18 +198,20 @@ class CMAwM:
             x = self._cma._sample_solution()
             if self._is_continuous_feasible(x[self._continuous_idx]):
                 x_encoded = x.copy()
-                x_encoded[self._discrete_idx] = self._encode_discrete_params(
-                    x[self._discrete_idx]
-                )
+                if self._n_zdim > 0:
+                    x_encoded[self._discrete_idx] = self._encode_discrete_params(
+                        x[self._discrete_idx]
+                    )
                 return x_encoded, x
         x = self._cma._sample_solution()
         x[self._continuous_idx] = self._repair_continuous_params(
             x[self._continuous_idx]
         )
         x_encoded = x.copy()
-        x_encoded[self._discrete_idx] = self._encode_discrete_params(
-            x[self._discrete_idx]
-        )
+        if self._n_zdim > 0:
+            x_encoded[self._discrete_idx] = self._encode_discrete_params(
+                x[self._discrete_idx]
+            )
         return x_encoded, x
 
     def _is_continuous_feasible(self, continuous_param: np.ndarray) -> bool:

--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import numpy as np
 
+from typing import cast
 from typing import Optional
 
 
@@ -114,6 +115,7 @@ class CMAwM:
         )
         n_dim = self._cma.dim
         population_size = self._cma.population_size
+        self._n_max_resampling = n_max_resampling
 
         # split discrete space and continuous space
         assert len(bounds) == len(steps), "bounds and steps must be the same length"
@@ -129,7 +131,11 @@ class CMAwM:
             discrete_space[i, : len(discrete)] = discrete
 
         # continuous_space contains low and high of each parameter.
-        assert _is_valid_bounds(bounds[steps <= 0], mean[steps <= 0]), "invalid bounds"
+        self._continuous_idx = np.where(steps <= 0)[0]
+        self._continuous_space = bounds[self._continuous_idx]
+        assert _is_valid_bounds(
+            self._continuous_space, mean[self._continuous_idx]
+        ), "invalid bounds"
 
         # discrete_space
         self._n_zdim = len(discrete_space)
@@ -188,13 +194,47 @@ class CMAwM:
         """Sample a parameter and return (i) encoded x and (ii) raw x.
         The encoded x is used for the evaluation.
         The raw x is used for updating the distribution."""
-        x = self._cma.ask()
+        for i in range(self._n_max_resampling):
+            x = self._cma._sample_solution()
+            if self._is_continuous_feasible(x[self._continuous_idx]):
+                x_encoded = x.copy()
+                x_encoded[self._discrete_idx] = self._encode_discrete_params(
+                    x[self._discrete_idx]
+                )
+                return x_encoded, x
+        x = self._cma._sample_solution()
+        x[self._continuous_idx] = self._repair_continuous_params(
+            x[self._continuous_idx]
+        )
         x_encoded = x.copy()
-        if self._n_zdim > 0:
-            x_encoded[self._discrete_idx] = self._encode_discrete_params(
-                x[self._discrete_idx]
-            )
+        x_encoded[self._discrete_idx] = self._encode_discrete_params(
+            x[self._discrete_idx]
+        )
         return x_encoded, x
+
+    def _is_continuous_feasible(self, continuous_param: np.ndarray) -> bool:
+        if self._continuous_space is None:
+            return True
+        return cast(
+            bool,
+            np.all(continuous_param >= self._continuous_space[:, 0])
+            and np.all(continuous_param <= self._continuous_space[:, 1]),
+        )  # Cast bool_ to bool.
+
+    def _repair_continuous_params(self, continuous_param: np.ndarray) -> np.ndarray:
+        if self._continuous_space is None:
+            return continuous_param
+
+        # clip with lower and upper bound.
+        param = np.where(
+            continuous_param < self._continuous_space[:, 0],
+            self._continuous_space[:, 0],
+            continuous_param,
+        )
+        param = np.where(
+            param > self._continuous_space[:, 1], self._continuous_space[:, 1], param
+        )
+        return param
 
     def _encode_discrete_params(self, discrete_param: np.ndarray) -> np.ndarray:
         """Encode the values into discrete domain."""


### PR DESCRIPTION
I observed a performance degradation from https://github.com/CyberAgentAILab/cmaes/pull/121#issuecomment-1296691448 in Optuna on HPO-bench: 
<img width="1852" alt="image" src="https://user-images.githubusercontent.com/23695091/210755387-924aa8b8-692f-4a37-ac43-a3eca0988a77.png">
(_CmaEsSampler_0_NopPruner: `CMA`, _CmaEsSampler_1_NopPruner: `CMAwM`)

I found out that this is caused by https://github.com/CyberAgentAILab/cmaes/pull/136 and https://github.com/CyberAgentAILab/cmaes/pull/140, which repair out-of-range discrete parameters in the same way as continuous parameters.

I'm not sure why this hurt the performance this much, but let me revert these changes for now. I confirmed that this PR brings the performance back to a similar level as the original:
<img width="1850" alt="image" src="https://user-images.githubusercontent.com/23695091/210758030-4bb5d306-4143-4b9a-822f-3475efefe125.png">
