### PR TITLE
fix the old_sigma assertion when lr_adapt=True

### DIFF
--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -400,9 +400,6 @@ class CMA:
 
         # Learning rate adaptation: https://arxiv.org/abs/2304.03473
         if self._lr_adapt:
-            assert isinstance(old_mean, np.ndarray)
-            assert isinstance(old_Sigma, np.ndarray)
-            assert isinstance(old_invsqrtC, np.ndarray)
             self._lr_adaptation(old_mean, old_sigma, old_Sigma, old_invsqrtC)
 
     def _lr_adaptation(

--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -401,7 +401,7 @@ class CMA:
         # Learning rate adaptation: https://arxiv.org/abs/2304.03473
         if self._lr_adapt:
             assert isinstance(old_mean, np.ndarray)
-            assert isinstance(old_sigma, float)
+            assert isinstance(old_sigma, (int, float))
             assert isinstance(old_Sigma, np.ndarray)
             assert isinstance(old_invsqrtC, np.ndarray)
             self._lr_adaptation(old_mean, old_sigma, old_Sigma, old_invsqrtC)

--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -401,7 +401,6 @@ class CMA:
         # Learning rate adaptation: https://arxiv.org/abs/2304.03473
         if self._lr_adapt:
             assert isinstance(old_mean, np.ndarray)
-            assert isinstance(old_sigma, (int, float))
             assert isinstance(old_Sigma, np.ndarray)
             assert isinstance(old_invsqrtC, np.ndarray)
             self._lr_adaptation(old_mean, old_sigma, old_Sigma, old_invsqrtC)


### PR DESCRIPTION
The current behavior : the assertion fails when lr_adapt=True and sigma is an integer (like sigma=1) which forces to put sigma = 1.0

With `assert isinstance(old_sigma, (int, float))` we allow integer values for sigma