### PR TITLE
Add tests for free-threaded python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,21 @@ jobs:
           python -m pip install --upgrade pip setuptools numpy scipy hypothesis
           pip install --progress-bar off .
       - run: python -m unittest
+  test-free-threaded:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # TODO: Replace deadsnakes with setup-python when the support for Python 3.13t is added
+      - name: Setup Python 3.13t
+        uses: deadsnakes/action@v3.1.0
+        with:
+          python-version: "3.13-dev"
+          nogil: true
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools numpy hypothesis
+          pip install --progress-bar off .
+      - run: python -m unittest
   test-numpy2:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,9 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools numpy scipy hypothesis
+          python -m pip install --upgrade pip setuptools numpy scipy hypothesis pytest
           pip install --progress-bar off .
-      - run: python -m unittest
+      - run: python -m pytest tests --ignore=tests/test_free_threaded.py
   test-free-threaded:
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +55,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools numpy hypothesis pytest pytest-freethreaded
           pip install --progress-bar off .
-      - run: python -m unittest
+      - run: python -m pytest --threads 1 --iterations 1 tests --ignore=tests/test_free_threaded.py
       # TODO: Using `unittest` style causes `pytest-freethreaded` to fail with `ConcurrencyError`.
       #       Rewriting as top-level functions works,
       #       so a follow-up is needed to refactor from `unittest` to `pytest`.
@@ -70,7 +70,7 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools scipy hypothesis
+          python -m pip install --upgrade pip setuptools scipy hypothesis pytest
           python -m pip install --pre --upgrade numpy
           pip install --progress-bar off .
-      - run: python -m unittest
+      - run: python -m pytest tests --ignore=tests/test_free_threaded.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,9 +53,10 @@ jobs:
           nogil: true
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools numpy hypothesis
+          python -m pip install --upgrade pip setuptools numpy hypothesis pytest pytest-freethreaded
           pip install --progress-bar off .
       - run: python -m unittest
+      - run: python -m pytest --threads 1 --iterations 1 --require-gil-disabled tests/test_free_threaded.py
   test-numpy2:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,9 @@ jobs:
           python -m pip install --upgrade pip setuptools numpy hypothesis pytest pytest-freethreaded
           pip install --progress-bar off .
       - run: python -m unittest
+      # TODO: Using `unittest` style causes `pytest-freethreaded` to fail with `ConcurrencyError`.
+      #       Rewriting as top-level functions works,
+      #       so a follow-up is needed to refactor from `unittest` to `pytest`.
       - run: python -m pytest --threads 1 --iterations 1 --require-gil-disabled tests/test_free_threaded.py
   test-numpy2:
     runs-on: ubuntu-latest

--- a/tests/test_free_threaded.py
+++ b/tests/test_free_threaded.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+from cmaes import CMA
+
+
+@pytest.mark.freethreaded(threads=10, iterations=200)
+def test_simple_optimization():
+    optimizer = CMA(mean=np.zeros(2), sigma=1.3)
+
+    def quadratic(x1: float, x2: float) -> float:
+        return (x1 - 3) ** 2 + (10 * (x2 + 2)) ** 2
+
+    while True:
+        solutions = []
+        for _ in range(optimizer.population_size):
+            x = optimizer.ask()
+            value = quadratic(x[0], x[1])
+            solutions.append((x, value))
+        optimizer.tell(solutions)
+
+        if optimizer.should_stop():
+            break


### PR DESCRIPTION
- Added a test using a Python 3.13t environment with experimental free-threading support
- Added a test to run simple CMA-based optimization tests in parallel using `pytest-freethreaded`