### PR TITLE
[Proposal] Support 1D search space in CMA-ES

### DIFF
--- a/cmaes/_cma.py
+++ b/cmaes/_cma.py
@@ -87,7 +87,7 @@ class CMA:
         ), f"Abs of all elements of mean vector must be less than {_MEAN_MAX}"
 
         n_dim = len(mean)
-        assert n_dim > 1, "The dimension of mean must be larger than 1"
+        assert n_dim > 0, "The dimension of mean must be positive"
 
         if population_size is None:
             population_size = 4 + math.floor(3 * math.log(n_dim))  # (eq. 48)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -10,7 +10,7 @@ class TestFuzzing(unittest.TestCase):
         data=st.data(),
     )
     def test_cma_tell(self, data):
-        dim = data.draw(st.integers(min_value=2, max_value=100))
+        dim = data.draw(st.integers(min_value=1, max_value=100))
         mean = data.draw(npst.arrays(dtype=float, shape=dim))
         sigma = data.draw(st.floats(min_value=1e-16))
         n_iterations = data.draw(st.integers(min_value=1))


### PR DESCRIPTION
### Motivation

At the moment, cmaes does not support 1D search space.
However, based on my understanding, the CMA-ES algorithm can naturally handle 1D search space, so I want to support it.
It has also been observed that some users want to support this (https://github.com/optuna/optuna/discussions/5524).

In this PR, I support 1D search space in CMA-ES.

### Description of Changes

- Change an assertion in `_cma.py` to ensure `n_dim > 0` rather than `n_dim > 1`.

I confirmed that the code with the above change passes all tests and works fine in the following toy example.

```python
import numpy as np
from cmaes import CMA

def quadratic(x1):
    return (x1 - 3) ** 2

if __name__ == "__main__":
    optimizer = CMA(mean=np.zeros(1), sigma=1.3)

    for generation in range(20):
        solutions = []
        for _ in range(optimizer.population_size):
            x = optimizer.ask()
            value = quadratic(x[0])
            solutions.append((x, value))
            print(f"#{generation} {value} (x1={x[0]})")
        optimizer.tell(solutions)
```

Output: It is confirmed that the search converges towards the optimum (`x1 = 3`).
```
#0 16.643669924292066 (x1=-1.0796654181797876)
#0 7.2004261524959166 (x1=0.3166390193460894)
#0 8.189839736380824 (x1=0.1382103962064533)
#0 12.497988920536582 (x1=-0.5352494849071942)
#1 7.179325689223134 (x1=0.3205736268329496)
#1 3.6146114323456273 (x1=1.0987868524687645)
#1 5.255710328044975 (x1=0.7074663954382319)
#1 10.095710257035286 (x1=-0.17737474293406053)
...
#18 6.963502924227799e-05 (x1=2.9916552394137232)
#18 0.002559389599251478 (x1=2.94940958984895)
#18 0.004124398005827681 (x1=3.0642214762040525)
#18 7.020158315938154e-05 (x1=2.991621361497273)
#19 0.0063421454828861525 (x1=3.0796375883793963)
#19 6.989768552220104e-05 (x1=2.991639516430122)
#19 0.0026858233887192963 (x1=2.948175069814622)
#19 0.0012593115389895819 (x1=3.0354867797776803)
```