### PR TITLE
Remove unnecessary 'global' declarations causing flake8 F824 errors

### DIFF
--- a/tools/cmaes_visualizer.py
+++ b/tools/cmaes_visualizer.py
@@ -198,7 +198,7 @@ def init():
 
 
 def get_next_popsize_sigma():
-    global optimizer, n_restarts, poptype, small_n_eval, large_n_eval, sigma0
+    global n_restarts, poptype, small_n_eval, large_n_eval
     if args.restart_strategy == "ipop":
         n_restarts += 1
         popsize = optimizer.population_size * inc_popsize

--- a/tools/ws_cmaes_visualizer.py
+++ b/tools/ws_cmaes_visualizer.py
@@ -241,8 +241,6 @@ def init():
 
 
 def update(frame):
-    global solutions
-
     for i in range(args.pop_per_frame):
         x1 = (x1_upper_bound - x1_lower_bound) * rng.random() + x1_lower_bound
         x2 = (x2_upper_bound - x2_lower_bound) * rng.random() + x2_lower_bound


### PR DESCRIPTION
This pull request addresses flake8 F824 errors that have emerged in the workflow tests when running with Python 3.13.2.
The errors are caused by unnecessary global declarations in functions where the variables are not reassigned.
No changes to the actual behavior of the code.