### PR TITLE
Reduce memory consumption in CMAwM

### DIFF
--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -119,14 +119,21 @@ class CMAwM:
         assert len(bounds) == len(steps), "bounds and steps must be the same length"
         assert not np.isnan(steps).any(), "steps should not include NaN"
         self._discrete_idx = np.where(steps > 0)[0]
-        discrete_list = [
-            np.arange(bounds[i][0], bounds[i][1] + steps[i] / 2, steps[i])
-            for i in self._discrete_idx
-        ]
-        max_discrete = max([len(discrete) for discrete in discrete_list], default=0)
-        discrete_space = np.full((len(self._discrete_idx), max_discrete), np.nan)
-        for i, discrete in enumerate(discrete_list):
-            discrete_space[i, : len(discrete)] = discrete
+        self._discrete_space_low = bounds[self._discrete_idx, 0]
+        requested_steps = steps[self._discrete_idx]
+        self._discrete_space_size = np.ceil(
+            (
+                bounds[self._discrete_idx, 1]
+                + requested_steps / 2
+                - self._discrete_space_low
+            )
+            / requested_steps
+        ).astype(int)
+        # np.arange uses dtype(start + step) - dtype(start) as its actual step.
+        # Retain that behavior without materializing every value in the range.
+        self._discrete_space_step = (
+            self._discrete_space_low + requested_steps - self._discrete_space_low
+        )
 
         # continuous_space contains low and high of each parameter.
         self._continuous_idx = np.where(steps <= 0)[0]
@@ -136,23 +143,17 @@ class CMAwM:
         )
 
         # discrete_space
-        self._n_zdim = len(discrete_space)
+        self._n_zdim = len(self._discrete_idx)
         if self._n_zdim == 0:
             return
+        assert np.all(self._discrete_space_size >= 2), (
+            "each discrete parameter must have at least two choices"
+        )
         self.margin = margin if margin is not None else 1 / (n_dim * population_size)
         assert self.margin > 0, "margin must be non-zero positive value."
-        self.z_space = discrete_space
-        self.z_lim = (self.z_space[:, 1:] + self.z_space[:, :-1]) / 2
-        for i in range(self._n_zdim):
-            self.z_space[i][np.isnan(self.z_space[i])] = np.nanmax(self.z_space[i])
-            self.z_lim[i][np.isnan(self.z_lim[i])] = np.nanmax(self.z_lim[i])
         m_z = self._cma._mean[self._discrete_idx]
         # m_z_lim_low ->|  mean vector    |<- m_z_lim_up
-        m_pos = np.array([np.searchsorted(self.z_lim[i], m_z[i]) for i in range(len(m_z))])
-        z_lim_low_index = np.clip(m_pos - 1, 0, self.z_lim.shape[1] - 1)
-        z_lim_up_index = np.clip(m_pos, 0, self.z_lim.shape[1] - 1)
-        self.m_z_lim_low = self.z_lim[np.arange(len(self.z_lim)), z_lim_low_index]
-        self.m_z_lim_up = self.z_lim[np.arange(len(self.z_lim)), z_lim_up_index]
+        self.m_z_lim_low, self.m_z_lim_up = self._get_discrete_param_limits(m_z)
 
         self._A = np.full(n_dim, 1.0)
 
@@ -233,9 +234,50 @@ class CMAwM:
         x = (discrete_param - mean[self._discrete_idx]) * self._A[self._discrete_idx] + mean[
             self._discrete_idx
         ]
-        x_pos = np.array([np.searchsorted(self.z_lim[i], x[i]) for i in range(len(x))])
-        x_enc = self.z_space[np.arange(len(self.z_space)), x_pos]
-        return x_enc
+        x_pos = self._get_discrete_param_indices(x)
+        return self._get_discrete_param_values(x_pos)
+
+    def _get_discrete_param_indices(self, values: np.ndarray) -> np.ndarray:
+        """Return indices of the closest discrete values, preferring the lower value on ties."""
+        indices = np.floor(
+            (values - self._discrete_space_low) / self._discrete_space_step + 0.5
+        ).astype(int)
+        indices = np.clip(indices, 0, self._discrete_space_size - 1)
+
+        # ``floor(x + 0.5)`` selects the upper value at an exact midpoint, while
+        # ``np.searchsorted`` used by the previous implementation selected the lower one.
+        has_lower_limit = indices > 0
+        lower_limits = self._get_discrete_param_limit_values(
+            np.maximum(indices - 1, 0)
+        )
+        indices -= has_lower_limit & (values <= lower_limits)
+
+        # Correct a possible one-position error caused by floating-point division.
+        has_upper_limit = indices < self._discrete_space_size - 1
+        upper_limits = self._get_discrete_param_limit_values(
+            np.minimum(indices, self._discrete_space_size - 2)
+        )
+        indices += has_upper_limit & (values > upper_limits)
+        return indices
+
+    def _get_discrete_param_values(self, indices: np.ndarray) -> np.ndarray:
+        return self._discrete_space_low + indices * self._discrete_space_step
+
+    def _get_discrete_param_limit_values(self, indices: np.ndarray) -> np.ndarray:
+        lower_values = self._get_discrete_param_values(indices)
+        upper_values = self._get_discrete_param_values(indices + 1)
+        return (lower_values + upper_values) / 2
+
+    def _get_discrete_param_limits(
+        self, values: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        positions = self._get_discrete_param_indices(values)
+        lower_indices = np.clip(positions - 1, 0, self._discrete_space_size - 2)
+        upper_indices = np.clip(positions, 0, self._discrete_space_size - 2)
+        return (
+            self._get_discrete_param_limit_values(lower_indices),
+            self._get_discrete_param_limit_values(upper_indices),
+        )
 
     def tell(self, solutions: list[tuple[np.ndarray, float]]) -> None:
         """Tell evaluation values"""
@@ -248,16 +290,9 @@ class CMAwM:
             return
         # margin correction
         updated_m_integer = mean[self._discrete_idx]
-        m_pos = np.array(
-            [
-                np.searchsorted(self.z_lim[i], updated_m_integer[i])
-                for i in range(len(updated_m_integer))
-            ]
+        self.m_z_lim_low, self.m_z_lim_up = self._get_discrete_param_limits(
+            updated_m_integer
         )
-        z_lim_low_index = np.clip(m_pos - 1, 0, self.z_lim.shape[1] - 1)
-        z_lim_up_index = np.clip(m_pos, 0, self.z_lim.shape[1] - 1)
-        self.m_z_lim_low = self.z_lim[np.arange(len(self.z_lim)), z_lim_low_index]
-        self.m_z_lim_up = self.z_lim[np.arange(len(self.z_lim)), z_lim_up_index]
 
         # calculate probability low_cdf := Pr(X <= m_z_lim_low) and up_cdf := Pr(m_z_lim_up < X)
         # sig_z_sq_Cdiag = self.model.sigma * self.model.A * np.sqrt(np.diag(self.model.C))

--- a/cmaes/_cmawm.py
+++ b/cmaes/_cmawm.py
@@ -122,11 +122,7 @@ class CMAwM:
         self._discrete_space_low = bounds[self._discrete_idx, 0]
         requested_steps = steps[self._discrete_idx]
         self._discrete_space_size = np.ceil(
-            (
-                bounds[self._discrete_idx, 1]
-                + requested_steps / 2
-                - self._discrete_space_low
-            )
+            (bounds[self._discrete_idx, 1] + requested_steps / 2 - self._discrete_space_low)
             / requested_steps
         ).astype(int)
         # np.arange uses dtype(start + step) - dtype(start) as its actual step.
@@ -247,9 +243,7 @@ class CMAwM:
         # ``floor(x + 0.5)`` selects the upper value at an exact midpoint, while
         # ``np.searchsorted`` used by the previous implementation selected the lower one.
         has_lower_limit = indices > 0
-        lower_limits = self._get_discrete_param_limit_values(
-            np.maximum(indices - 1, 0)
-        )
+        lower_limits = self._get_discrete_param_limit_values(np.maximum(indices - 1, 0))
         indices -= has_lower_limit & (values <= lower_limits)
 
         # Correct a possible one-position error caused by floating-point division.
@@ -268,9 +262,7 @@ class CMAwM:
         upper_values = self._get_discrete_param_values(indices + 1)
         return (lower_values + upper_values) / 2
 
-    def _get_discrete_param_limits(
-        self, values: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray]:
+    def _get_discrete_param_limits(self, values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         positions = self._get_discrete_param_indices(values)
         lower_indices = np.clip(positions - 1, 0, self._discrete_space_size - 2)
         upper_indices = np.clip(positions, 0, self._discrete_space_size - 2)
@@ -290,9 +282,7 @@ class CMAwM:
             return
         # margin correction
         updated_m_integer = mean[self._discrete_idx]
-        self.m_z_lim_low, self.m_z_lim_up = self._get_discrete_param_limits(
-            updated_m_integer
-        )
+        self.m_z_lim_low, self.m_z_lim_up = self._get_discrete_param_limits(updated_m_integer)
 
         # calculate probability low_cdf := Pr(X <= m_z_lim_low) and up_cdf := Pr(m_z_lim_up < X)
         # sig_z_sq_Cdiag = self.model.sigma * self.model.A * np.sqrt(np.diag(self.model.C))

--- a/tests/test_cmawm.py
+++ b/tests/test_cmawm.py
@@ -2,8 +2,48 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 from unittest import TestCase
 from cmaes import CMA, CMAwM
+
+
+class _DenseCMAwM(CMAwM):
+    """CMAwM using the dense discretization tables from the previous implementation."""
+
+    def __init__(self, *args, **kwargs):
+        bounds = kwargs["bounds"]
+        steps = kwargs["steps"]
+        discrete_idx = np.where(steps > 0)[0]
+        discrete_list = [
+            np.arange(bounds[i][0], bounds[i][1] + steps[i] / 2, steps[i])
+            for i in discrete_idx
+        ]
+        max_discrete = max([len(discrete) for discrete in discrete_list], default=0)
+        self._dense_z_space = np.full((len(discrete_idx), max_discrete), np.nan)
+        for i, discrete in enumerate(discrete_list):
+            self._dense_z_space[i, : len(discrete)] = discrete
+        self._dense_z_lim = (
+            self._dense_z_space[:, 1:] + self._dense_z_space[:, :-1]
+        ) / 2
+        for i in range(len(discrete_idx)):
+            self._dense_z_space[i][np.isnan(self._dense_z_space[i])] = np.nanmax(
+                self._dense_z_space[i]
+            )
+            self._dense_z_lim[i][np.isnan(self._dense_z_lim[i])] = np.nanmax(
+                self._dense_z_lim[i]
+            )
+        super().__init__(*args, **kwargs)
+
+    def _get_discrete_param_indices(self, values):
+        return np.array(
+            [np.searchsorted(self._dense_z_lim[i], values[i]) for i in range(len(values))]
+        )
+
+    def _get_discrete_param_values(self, indices):
+        return self._dense_z_space[np.arange(len(indices)), indices]
+
+    def _get_discrete_param_limit_values(self, indices):
+        return self._dense_z_lim[np.arange(len(indices)), indices]
 
 
 class TestCMAwM(TestCase):
@@ -31,3 +71,76 @@ class TestCMAwM(TestCase):
                 solutions.append((cma_x, objective))
             cma_optimizer.tell(solutions)
             cmawm_optimizer.tell(solutions)
+
+    def test_sampling_is_equivalent_to_dense_discretization(self):
+        mean = np.array([0.0, 0.0, 0.0])
+        bounds = np.array([[-30.0, 30.0], [-4.0, 4.0], [-5.0, 5.0]])
+        steps = np.array([0.001, 0.5, 0.0])
+        kwargs = {
+            "mean": mean,
+            "sigma": 1.3,
+            "bounds": bounds,
+            "steps": steps,
+            "seed": 1,
+        }
+        optimizer = CMAwM(**kwargs)
+        dense_optimizer = _DenseCMAwM(**kwargs)
+
+        for _ in range(30):
+            solutions = []
+            dense_solutions = []
+            for _ in range(optimizer.population_size):
+                x_for_eval, x_for_tell = optimizer.ask()
+                dense_x_for_eval, dense_x_for_tell = dense_optimizer.ask()
+
+                assert_allclose(x_for_eval, dense_x_for_eval, rtol=0, atol=1e-12)
+                assert_allclose(x_for_tell, dense_x_for_tell, rtol=0, atol=1e-12)
+
+                # Pass the same objective value to both optimizers so this test isolates
+                # differences in sampling and discretization from objective round-off.
+                value = float(np.sum(x_for_eval**2))
+                solutions.append((x_for_tell, value))
+                dense_solutions.append((x_for_tell, value))
+
+            optimizer.tell(solutions)
+            dense_optimizer.tell(dense_solutions)
+            assert_allclose(optimizer.mean, dense_optimizer.mean, rtol=0, atol=1e-12)
+            assert_allclose(optimizer._A, dense_optimizer._A, rtol=0, atol=1e-12)
+
+    def test_discrete_encoding_is_equivalent_to_dense_discretization(self):
+        bounds = np.array([[-30.0, 30.0], [-4.0, 4.0], [-1.0, 1.0]])
+        steps = np.array([0.001, 0.5, 0.3])
+        kwargs = {
+            "mean": np.zeros(3),
+            "sigma": 1.3,
+            "bounds": bounds,
+            "steps": steps,
+            "seed": 1,
+        }
+        optimizer = CMAwM(**kwargs)
+        dense_optimizer = _DenseCMAwM(**kwargs)
+        rng = np.random.RandomState(0)
+
+        for _ in range(1000):
+            values = rng.uniform(bounds[:, 0] - 1, bounds[:, 1] + 1)
+            indices = optimizer._get_discrete_param_indices(values)
+            dense_indices = dense_optimizer._get_discrete_param_indices(values)
+            assert_allclose(
+                optimizer._get_discrete_param_values(indices),
+                dense_optimizer._get_discrete_param_values(dense_indices),
+                rtol=0,
+                atol=1e-12,
+            )
+
+        for dimension, size in enumerate(optimizer._discrete_space_size):
+            for limit_index in (0, size // 2, size - 2):
+                values = np.zeros(3)
+                values[dimension] = dense_optimizer._dense_z_lim[dimension, limit_index]
+                indices = optimizer._get_discrete_param_indices(values)
+                dense_indices = dense_optimizer._get_discrete_param_indices(values)
+                assert_allclose(
+                    optimizer._get_discrete_param_values(indices),
+                    dense_optimizer._get_discrete_param_values(dense_indices),
+                    rtol=0,
+                    atol=1e-12,
+                )

--- a/tests/test_cmawm.py
+++ b/tests/test_cmawm.py
@@ -2,48 +2,8 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from numpy.testing import assert_allclose
 from unittest import TestCase
 from cmaes import CMA, CMAwM
-
-
-class _DenseCMAwM(CMAwM):
-    """CMAwM using the dense discretization tables from the previous implementation."""
-
-    def __init__(self, *args, **kwargs):
-        bounds = kwargs["bounds"]
-        steps = kwargs["steps"]
-        discrete_idx = np.where(steps > 0)[0]
-        discrete_list = [
-            np.arange(bounds[i][0], bounds[i][1] + steps[i] / 2, steps[i])
-            for i in discrete_idx
-        ]
-        max_discrete = max([len(discrete) for discrete in discrete_list], default=0)
-        self._dense_z_space = np.full((len(discrete_idx), max_discrete), np.nan)
-        for i, discrete in enumerate(discrete_list):
-            self._dense_z_space[i, : len(discrete)] = discrete
-        self._dense_z_lim = (
-            self._dense_z_space[:, 1:] + self._dense_z_space[:, :-1]
-        ) / 2
-        for i in range(len(discrete_idx)):
-            self._dense_z_space[i][np.isnan(self._dense_z_space[i])] = np.nanmax(
-                self._dense_z_space[i]
-            )
-            self._dense_z_lim[i][np.isnan(self._dense_z_lim[i])] = np.nanmax(
-                self._dense_z_lim[i]
-            )
-        super().__init__(*args, **kwargs)
-
-    def _get_discrete_param_indices(self, values):
-        return np.array(
-            [np.searchsorted(self._dense_z_lim[i], values[i]) for i in range(len(values))]
-        )
-
-    def _get_discrete_param_values(self, indices):
-        return self._dense_z_space[np.arange(len(indices)), indices]
-
-    def _get_discrete_param_limit_values(self, indices):
-        return self._dense_z_lim[np.arange(len(indices)), indices]
 
 
 class TestCMAwM(TestCase):
@@ -71,76 +31,3 @@ class TestCMAwM(TestCase):
                 solutions.append((cma_x, objective))
             cma_optimizer.tell(solutions)
             cmawm_optimizer.tell(solutions)
-
-    def test_sampling_is_equivalent_to_dense_discretization(self):
-        mean = np.array([0.0, 0.0, 0.0])
-        bounds = np.array([[-30.0, 30.0], [-4.0, 4.0], [-5.0, 5.0]])
-        steps = np.array([0.001, 0.5, 0.0])
-        kwargs = {
-            "mean": mean,
-            "sigma": 1.3,
-            "bounds": bounds,
-            "steps": steps,
-            "seed": 1,
-        }
-        optimizer = CMAwM(**kwargs)
-        dense_optimizer = _DenseCMAwM(**kwargs)
-
-        for _ in range(30):
-            solutions = []
-            dense_solutions = []
-            for _ in range(optimizer.population_size):
-                x_for_eval, x_for_tell = optimizer.ask()
-                dense_x_for_eval, dense_x_for_tell = dense_optimizer.ask()
-
-                assert_allclose(x_for_eval, dense_x_for_eval, rtol=0, atol=1e-12)
-                assert_allclose(x_for_tell, dense_x_for_tell, rtol=0, atol=1e-12)
-
-                # Pass the same objective value to both optimizers so this test isolates
-                # differences in sampling and discretization from objective round-off.
-                value = float(np.sum(x_for_eval**2))
-                solutions.append((x_for_tell, value))
-                dense_solutions.append((x_for_tell, value))
-
-            optimizer.tell(solutions)
-            dense_optimizer.tell(dense_solutions)
-            assert_allclose(optimizer.mean, dense_optimizer.mean, rtol=0, atol=1e-12)
-            assert_allclose(optimizer._A, dense_optimizer._A, rtol=0, atol=1e-12)
-
-    def test_discrete_encoding_is_equivalent_to_dense_discretization(self):
-        bounds = np.array([[-30.0, 30.0], [-4.0, 4.0], [-1.0, 1.0]])
-        steps = np.array([0.001, 0.5, 0.3])
-        kwargs = {
-            "mean": np.zeros(3),
-            "sigma": 1.3,
-            "bounds": bounds,
-            "steps": steps,
-            "seed": 1,
-        }
-        optimizer = CMAwM(**kwargs)
-        dense_optimizer = _DenseCMAwM(**kwargs)
-        rng = np.random.RandomState(0)
-
-        for _ in range(1000):
-            values = rng.uniform(bounds[:, 0] - 1, bounds[:, 1] + 1)
-            indices = optimizer._get_discrete_param_indices(values)
-            dense_indices = dense_optimizer._get_discrete_param_indices(values)
-            assert_allclose(
-                optimizer._get_discrete_param_values(indices),
-                dense_optimizer._get_discrete_param_values(dense_indices),
-                rtol=0,
-                atol=1e-12,
-            )
-
-        for dimension, size in enumerate(optimizer._discrete_space_size):
-            for limit_index in (0, size // 2, size - 2):
-                values = np.zeros(3)
-                values[dimension] = dense_optimizer._dense_z_lim[dimension, limit_index]
-                indices = optimizer._get_discrete_param_indices(values)
-                dense_indices = dense_optimizer._get_discrete_param_indices(values)
-                assert_allclose(
-                    optimizer._get_discrete_param_values(indices),
-                    dense_optimizer._get_discrete_param_values(dense_indices),
-                    rtol=0,
-                    atol=1e-12,
-                )


### PR DESCRIPTION
## Background

This change was motivated by [optuna/optuna#5762](https://github.com/optuna/optuna/issues/5762), which reported that using `CmaEsSampler` with margin could significantly increase the Optuna journal file size. In the reported example, ten parameters over `[-30, 30]` with a step size of `0.001` produced a journal file of about 40 MB after only 12 trials.

The dense discrete-value tables stored in `CMAwM` contribute to the size of the serialized optimizer state. This PR replaces them with a compact arithmetic representation.

## Summary

- Replace dense discrete-value tables with arithmetic representations using lower bounds, step sizes, and choice counts.
- Preserve the existing discretization behavior, including midpoint handling.
- Significantly reduce initialization memory usage and serialized object size.

## Results

For 10 dimensions over [-30, 30] with a step size of 0.001 (60,001 discrete values per dimension):

- Discrete representation: 9.16 MiB → 240 B (>99.99% reduction)
- Pickle size: 9.16 MiB → 4.43 KiB (>99.9% reduction)

The new implementation was verified against the previous dense implementation, and all tests pass.

 ### Verification

I compared the new arithmetic representation against the previous dense implementation using a standalone verification and benchmark script: https://gist.github.com/y0z/2a65eb996dccd7f220f1986c250c819a.

```bash
  python cmawm_memory.py
```

The implementations produced equivalent sampling and update results.