### PR TITLE
Fix SafeCMA example workflow on Python 3.14

### DIFF
--- a/cmaes/safe_cma.py
+++ b/cmaes/safe_cma.py
@@ -286,7 +286,7 @@ class SafeCMA:
         modified_evals = (target_safe_evals - evals_mean) / evals_std
 
         # function that returns the negative norm of gradient
-        def df(x: np.ndarray, model: ExactGPModel) -> torch.Tensor:
+        def df(x: np.ndarray, model: ExactGPModel) -> float | np.ndarray:
             out_scalar = x.ndim == 1
             x = np.atleast_2d(x)
 
@@ -300,8 +300,9 @@ class SafeCMA:
 
             if out_scalar:
                 grad_norm = grad_norm.mean().to(torch.float64)
+                return -grad_norm.item()
 
-            return -grad_norm
+            return -grad_norm.detach().numpy()
 
         def elementwise_df(i: int) -> float:
             samples = self._rng.randn(self.sample_num_lip, self._n_dim)


### PR DESCRIPTION
Fix the SafeCMA example workflow failure on Python 3.14.

The objective function passed to `scipy.optimize.minimize` now returns a Python `float`, while batched evaluations are converted to NumPy arrays. This avoids compatibility issues between SciPy, NumPy, and PyTorch without changing the optimization behavior.