### PR TITLE
Exclude Markdown files from Ruff checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ disallow_untyped_defs = true
 
 [tool.ruff]
 line-length = 99
+extend-exclude = ["*.md"]
 exclude = [
     ".eggs",
     ".git",


### PR DESCRIPTION
Exclude Markdown files from Ruff linting and formatting.

Ruff 0.16.0 started formatting Python code blocks in Markdown files by default, causing existing README examples to fail `ruff format --check .`. This change adds `*.md` to `extend-exclude` to preserve the previous CI scope.